### PR TITLE
chore: add discourse badge

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,0 +1,3 @@
+module.exports = {
+    bundlesize: { maxSize: '110kB' }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+language: node_js
+cache: npm
+
+stages:
+  - check
+  - test
+  - cov
+
+node_js:
+  - '10'
+
+os:
+  - linux
+  - osx
+
+script: npx nyc -s npm run test:node -- --bail
+after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov
+
+jobs:
+  include:
+    - os: windows
+      filter_secrets: false
+      cache: false
+
+    - stage: check
+      script:
+        - npx aegir build --bundlesize
+        - npx aegir commitlint --travis
+        - npx aegir dep-check
+        - npm run lint
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 js-libp2p-pnet
 ==================
 
+[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)
+[![](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
+[![](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
+[![Discourse posts](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg)](https://discuss.libp2p.io)
+[![](https://img.shields.io/codecov/c/github/libp2p/js-libp2p-pnet.svg?style=flat-square)](https://codecov.io/gh/libp2p/js-libp2p-pnet)
+[![](https://img.shields.io/travis/libp2p/js-libp2p-pnet.svg?style=flat-square)](https://travis-ci.com/libp2p/js-libp2p-pnet)
+[![Dependency Status](https://david-dm.org/libp2p/js-libp2p-pnet.svg?style=flat-square)](https://david-dm.org/libp2p/js-libp2p-pnet)
+[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/feross/standard)
+
 Connection protection management for libp2p leveraging PSK encryption via XSalsa20.
 
 ## Lead Maintainer

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,2 +1,0 @@
-// Warning: This file is automatically synced from https://github.com/ipfs/ci-sync so if you want to change it, please change it there and ask someone to sync all repositories.
-javascript()

--- a/package.json
+++ b/package.json
@@ -25,21 +25,21 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "debug": "^3.1.0",
-    "interface-connection": "~0.3.2",
+    "debug": "^4.1.1",
+    "interface-connection": "~0.3.3",
     "pull-cat": "^1.1.11",
-    "pull-defer": "~0.2.2",
+    "pull-defer": "~0.2.3",
     "pull-handshake": "^1.1.4",
     "pull-reader": "^1.3.1",
-    "pull-stream": "^3.6.7",
+    "pull-stream": "^3.6.9",
     "xsalsa20": "^1.0.2"
   },
   "devDependencies": {
-    "aegir": "^15.0.0",
-    "async": "^2.6.1",
-    "chai": "^4.1.2",
+    "aegir": "^18.2.2",
+    "async": "^2.6.2",
+    "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
-    "peer-id": "~0.10.7",
+    "peer-id": "~0.12.2",
     "pull-pair": "^1.1.0"
   },
   "engines": {


### PR DESCRIPTION
In the context of [libp2p/libp2p#74](https://github.com/libp2p/libp2p/issues/74), the badge for [discuss.libp2p.io](http://discuss.libp2p.io) was added.

Dependencies were also updated and travis CI added