### PR TITLE
chore: add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+⛔️ DEPRECATED: libp2p-pnet is now included in [js-libp2p](https://github.com/libp2p/js-libp2p)
+=====
+
 js-libp2p-pnet
 ==================
 


### PR DESCRIPTION
DEPRECATED: Pnet is now part of the js-libp2p repo.